### PR TITLE
Made render passes configurable and some layout fixes.

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -67,7 +67,7 @@
 %% flag makes the checkbox value and the return value of the field to
 %% be the inverted minimized state (the maximized state ;-).
 %%
-%% {oframe,Fields[,Flags]}                      -- Overlay frame
+%% {oframe,Fields,Focused[,Flags]}                      -- Overlay frame
 %%     Flags = [Flag]
 %%     Flag = {title,String}|{style,Style}|{key,Key}|{hook,Hook}|layout
 %%     Style = menu|buttons  -- menu is default
@@ -839,7 +839,7 @@ build(Ask, {oframe, Tabs, Def, Flags}, Parent, WinSizer, In0)
 	      end,
     In = lists:foldl(AddPage, In0, Tabs),
     case Def =< length(In) of
-	true -> wxNotebook:setSelection(NB, Def+1);
+	true -> wxNotebook:setSelection(NB, Def-1);
 	false -> ignore
     end,
     wxSizer:add(WinSizer, NB, [{proportion, 1},{flag, ?wxEXPAND}]),


### PR DESCRIPTION
- Added option to enable/disable render passes as well as the max render passes
  to be shown in the Render Options dialog.
  That max render passes can be ignored if a previously saved project uses a
  number greater than it;
- Fixed bad default tab selection. That was causing the tab controls to show
  other than the first tab as active (selected);
- Fixed some minor layout spacement between group boxes (hframe) by using the
  'panel' control;
