### PR TITLE
Fixed the missing fields on Material tab

### DIFF
--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -1109,18 +1109,18 @@ material_dialog(_Name, Mat) ->
                         {"Dispersion Power", {slider, {text,DispersionPower,[range(dispersion_power),key(dispersion_power)]}}}
                     ],[{margin,false}]},
                     {"Fake Shadows",FakeShadows,[key(fake_shadows)]}
-                ],[key(pnl_dsp),{show,false},{margin,false}]},
+                ],[key(pnl_dsp),{margin,false}]},
                 %% 17th row
                 {hframe, [
                     {"Oren-Nayar",OrenNayar,[key(oren_nayar),{hook,Hook_Enable}]},
                     {label_column,[
                         {"Sigma", {text,OrenNayar_Sigma,[range(oren_nayar_sigma),key(oren_nayar_sigma)]}}
                     ],[key(pnl_sigma_shiny),{margin,false}]}
-                ],[key(pnl_on),{show,false},{margin,false}]},
+                ],[key(pnl_on),{margin,false}]},
                 %% 18th row
                 {hframe, [
                     {"Fresnel Effect",TIR,[key(tir)]}
-                ],[key(pnl_fe),{show,false},{margin,false}]},
+                ],[key(pnl_fe),{margin,false}]},
                 %% 19th row
                 {label_column, [
                     {"Color", {slider, {color,Lightmat_Color,[key(lightmat_color)]}}},


### PR DESCRIPTION
It was missing some fields in Material dialog: the 'Fake Shadows' for Rough
Glass and 'Emit Ligth', 'Oren-Nayar' and 'Fresnel Effect' for Shinny Diffuse.

That happened due to deprecated fields that were removed. Dynamics dialogs in
Wings3D (the ones we show/hide fields) requires we to hide some fields
in order the dialog doesn't reserve a high frame to show all the added fields.
As some fields were removed the height reserved was not enough to display all
of them.

We need to be sure to keep visible  all the fiedls that can be shown at one
specific moment in which the dialog will have highest high.