### PR TITLE
Fixed unicode formating in the exporter

### DIFF
--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -3133,17 +3133,16 @@ export(Attr, Filename, #e3d_file{objs=Objs,mat=Mats,creator=Creator}) ->
                 {Filename,filename:rootname(Filename)++Ext}
         end,
     F = open(ExportFile, export),
-    io:format(?__(1,"Exporting  to:")++" ~s~n"++
-                  ?__(2,"for render to:")++" ~s~n", [ExportFile,RenderFile]),
+    io:format(?__(1,"Exporting  to:")++" ~ts~n"++
+                  ?__(2,"for render to:")++" ~ts~n", [ExportFile,RenderFile]),
     CreatorChg = re:replace(Creator,"-","_",[global]),
     CameraName = "x_Camera",
     ConstBgName = "x_ConstBackground",
     Lights = proplists:get_value(lights, Attr, []),
     %%
-    println(F,  "<?xml version=\"1.0\"?>~n"++
-                "<!-- ~s: Exported from ~s -->~n"++
+    uniprintln(F,  "<?xml version=\"1.0\"?>~n"++
+                "<!-- ~ts: Exported from ~s -->~n"++
                 "~n"++
-
                 "<scene type=\"triangle\">", [filename:basename(ExportFile), CreatorChg]),
     %%
     section(F, "Materials"),
@@ -3332,8 +3331,8 @@ export_shinydiffuse_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"shinydiffusemat\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"shinydiffusemat\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3428,8 +3427,8 @@ export_glossy_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"glossy\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"glossy\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3524,8 +3523,8 @@ export_coatedglossy_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-               "<type sval=\"coated_glossy\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"coated_glossy\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3629,8 +3628,8 @@ export_glass_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"glass\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"glass\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3718,8 +3717,8 @@ export_rough_glass_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"rough_glass\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"rough_glass\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3810,8 +3809,8 @@ export_lightmat_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"light_mat\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"light_mat\"/>", [Name]),
     _DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     DefLightmatColor = def_lightmat_color(proplists:get_value(diffuse, OpenGL)),
@@ -3909,8 +3908,8 @@ export_blend_mat_shader(F, Name, Mat, ExportDir, YafaRay) ->
               (_, N) ->
                   N % Ignore old modulators
           end, 1, Modulators),
-    println(F, "<material name=\"~s\">~n"++
-                "<type sval=\"blend_mat\"/>", [Name]),
+    uniprintln(F, "<material name=\"~ts\">~n"++
+                  "<type sval=\"blend_mat\"/>", [Name]),
     DiffuseA = {_,_,_,Opacity} = proplists:get_value(diffuse, OpenGL),
 
     Specular = alpha(proplists:get_value(specular, OpenGL)),
@@ -3936,9 +3935,9 @@ export_blend_mat_shader(F, Name, Mat, ExportDir, YafaRay) ->
 
     Blend_Value = proplists:get_value(blend_value, YafaRay, ?DEF_BLEND_VALUE),
 
-    println(F, "  <material1 sval=\"""w_""\~s\"/>~n"
-            "        <material2 sval=\"""w_""\~s\"/>~n"
-            "        <blend_value fval=\"~.10f\"/>~n",
+    uniprintln(F, "  <material1 sval=\"""w_""\~ts\"/>~n"
+                  "        <material2 sval=\"""w_""\~ts\"/>~n"
+                  "        <blend_value fval=\"~.10f\"/>~n",
             [Blend_Mat1,Blend_Mat2,Blend_Value]),
     foldl(fun ({modulator,Ps}=M, N) when is_list(Ps) ->
                   case export_modulator(F, [Name,$_,format(N)],
@@ -3996,12 +3995,12 @@ export_texture(F, Name, Maps, ExportDir, {modulator,Ps}) when is_list(Ps) ->
     end.
 
 export_texture(F, Name, image, Filename) ->
-    println(F, "<texture name=\"~s\">~n"++
-                "    <filename sval=\"~s\"/>~n"++
-                "<type sval=\"image\"/>~n" ++
-                "</texture>", [Name,Filename]);
+    uniprintln(F, "<texture name=\"~ts\">~n"++
+                  "    <filename sval=\"~ts\"/>~n"++
+                  "<type sval=\"image\"/>~n" ++
+                  "</texture>", [Name,Filename]);
 export_texture(F, Name, Type, Ps) ->
-    println(F, "<texture name=\"~s\"> <type sval=\"~s\"/>", [Name,format(Type)]),
+    uniprintln(F, "<texture name=\"~ts\"> <type sval=\"~s\"/>", [Name,format(Type)]),
 
     Color1 = proplists:get_value(color1, Ps, ?DEF_MOD_COLOR1),
     Color2 = proplists:get_value(color2, Ps, ?DEF_MOD_COLOR2),
@@ -4113,7 +4112,8 @@ set_map_type(Filepath0,Ext) ->
     Filepath = filename:rootname(Filepath0),
     Filepath ++ Ext.
 
-export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
+export_modulator(F, Texname0, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
+    Texname = lists:flatten(Texname0),
     case mod_enabled_mode_type(Ps, Maps) of
         {false,_,_} ->
             off;
@@ -4125,8 +4125,8 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
 
             UpperLayerName =
                 case AlphaIntensity of
-                    stencil -> re:replace(Texname,"_2","_1",[global]);
-                    _-> re:replace(Texname,"_1","_2",[global])
+                    stencil -> re:replace(Texname,"_2","_1",[global,unicode]);
+                    _-> re:replace(Texname,"_1","_2",[global,unicode])
                 end,
 
 %%% End Change Number from Texname for UpperLayer
@@ -4135,7 +4135,7 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
 
             StencilInputName =
                 case AlphaIntensity of
-                    stencil -> re:replace(Texname,"_2","_3",[global]);
+                    stencil -> re:replace(Texname,"_2","_3",[global,unicode]);
                     _-> ""
                 end,
 
@@ -4145,7 +4145,7 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
 
             StencilUpperLayerName2 =
                 case AlphaIntensity of
-                    stencil -> re:replace(Texname,"_1","_2",[global]);
+                    stencil -> re:replace(Texname,"_1","_2",[global,unicode]);
                     _-> ""
                 end,
 
@@ -4191,7 +4191,7 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
                 end,
 
 %% Start Identify Modulator # (w_default_Name_1 or w_default_Name_2)
-            Split=re:split(Texname,"_",[{return, list}]),
+            Split=re:split(Texname,"_",[{return, list},unicode]),
             Num=lists:last(Split),
             UpperLayer =
                 case {Num,Mode,AlphaIntensity} of
@@ -4267,12 +4267,12 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
             case AlphaIntensity of
                 stencil ->
 %%Stencil Export Start
-                    println(F, " <!--Start Stencil Section Here-->
+                    uniprintln(F, " <!--Start Stencil Section Here-->
 
                                 <list_element>
                                 <element sval=\"shader_node\"/>
-                                <name sval=\"~s\"/>
-                                <input sval=\"~s_mod\"/>
+                                <name sval=\"~ts\"/>
+                                <input sval=\"~ts_mod\"/>
 
                                 <noRGB bval=\"true\"/>
                                 <stencil bval=\"true\"/>
@@ -4284,10 +4284,10 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
 
                                 <list_element>
                                 <element sval=\"shader_node\"/>
-                                <name sval=\"~s_mod\"/>
+                                <name sval=\"~ts_mod\"/>
                                 "++TexCo++"
                                 <mapping sval=\"plain\"/>
-                                <texture sval=\"~s\"/>
+                                <texture sval=\"~ts\"/>
                                 <type sval=\"texture_mapper\"/>
                                 <bump_strength fval=\"~.3f\"/>
                                 </list_element>
@@ -4308,11 +4308,11 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
 %%Stencil Export End
                 _ ->
 
-                    println(F, "  "++ShaderName++"
+                    uniprintln(F, "  "++ShaderName++"
                                 <list_element>
                                 <element sval=\"shader_node\"/>
-                                <name sval=\"~s\"/>
-                                <input sval=\"~s_mod\"/>
+                                <name sval=\"~ts\"/>
+                                <input sval=\"~ts_mod\"/>
                                 "++UpperLayer++"
                                 "++UpperColor++"
                                 "++UseAlpha++"
@@ -4323,10 +4323,10 @@ export_modulator(F, Texname, Maps, {modulator,Ps}, _Opacity) when is_list(Ps) ->
                                 </list_element>
                                 <list_element>
                                 <element sval=\"shader_node\"/>
-                                <name sval=\"~s_mod\"/>
+                                <name sval=\"~ts_mod\"/>
                                 "++TexCo++"
                                 <mapping sval=\"plain\"/>
-                                <texture sval=\"~s\"/>
+                                <texture sval=\"~ts\"/>
                                 <type sval=\"texture_mapper\"/>
                                 <scale x=\"~.3f\" y=\"~.3f\" z=\"~.3f\"/>
                                 <bump_strength fval=\"~.3f\"/>
@@ -4416,7 +4416,7 @@ export_object_1(F, NameStr, Mesh0=#e3d_mesh{he=He0}, DefaultMaterial, MatPs, Id)
     Mesh1 = #e3d_mesh{} =
         case {He0,UseHardness} of
             {[_|_],true} ->
-                io:format(?__(1,"Mesh ~s: slitting hard edges..."), [NameStr]),
+                io:format(?__(1,"Mesh ~ts: slitting hard edges..."), [NameStr]),
                 M1 = e3d_mesh:slit_hard_edges(Mesh0, [slit_end_vertices]),
                 io:format(?__(2,"done")++"~n"),
                 M1;
@@ -4424,15 +4424,15 @@ export_object_1(F, NameStr, Mesh0=#e3d_mesh{he=He0}, DefaultMaterial, MatPs, Id)
         end,
 
 
-    io:format(?__(3,"Mesh ~s: triangulating..."), [NameStr]),
+    io:format(?__(3,"Mesh ~ts: triangulating..."), [NameStr]),
     #e3d_mesh{fs=Fs,vs=Vs,vc=Vc,tx=Tx} = e3d_mesh:triangulate(Mesh1),
     io:format(?__(4,"done")++"~n"),
-    io:format(?__(5,"Mesh ~s: exporting..."), [NameStr]),
+    io:format(?__(5,"Mesh ~ts: exporting..."), [NameStr]),
     %%
 
     %% Add Export Object Name Start
 
-    println(F, "<!--Object Name ~s, Object # ~w-->", [NameStr,Id]),
+    uniprintln(F, "<!--Object Name ~ts, Object # ~w-->", [NameStr,Id]),
 
     %% Add Export Object Name End
 
@@ -4472,7 +4472,7 @@ export_object_1(F, NameStr, Mesh0=#e3d_mesh{he=He0}, DefaultMaterial, MatPs, Id)
                     println(F, "<sharpness fval=\"~.10f\"/>",[Volume_Sharpness]),
                     println(F, "<cover fval=\"~.10f\"/>",[Volume_Cover]),
                     println(F, "<density fval=\"~.10f\"/>",[Volume_Density]),
-                    println(F, "<texture sval=\"w_~s_1\"/>",[DefaultMaterial])
+                    uniprintln(F, "<texture sval=\"w_~ts_1\"/>",[DefaultMaterial])
 
             end,
 
@@ -4492,7 +4492,7 @@ export_object_1(F, NameStr, Mesh0=#e3d_mesh{he=He0}, DefaultMaterial, MatPs, Id)
 
         meshlight ->
             println(F," "),
-            println(F, "<light name=\"~s\">",[NameStr]),
+            uniprintln(F, "<light name=\"~ts\">",[NameStr]),
 
             export_rgb(F, color, proplists:get_value(meshlight_color, YafaRay, Meshlight_Color)),
 
@@ -4508,7 +4508,7 @@ export_object_1(F, NameStr, Mesh0=#e3d_mesh{he=He0}, DefaultMaterial, MatPs, Id)
 
         lightportal ->
             println(F," "),
-            println(F, "<light name=\"~s\">",[NameStr]),
+            uniprintln(F, "<light name=\"~ts\">",[NameStr]),
             println(F, "<type sval=\"bgPortalLight\"/>"),
             println(F, "<power fval=\"~.10f\"/>",[Lightportal_Power]),
             println(F, "<samples ival=\"~w\"/>",[Lightportal_Samples]),
@@ -4655,9 +4655,9 @@ export_faces(F, [#e3d_face{mat=[Mat|_],tx=Tx,vs=[A,B,C],vc=VCols}|T],
                              [length(VCols)]),
                    ""
            end,
-    println(F, [Shader, "        <f a=\"",format(A),
+    uniprintln(F, [Shader, "        <f a=\"",format(A),
                 "\" b=\"",format(B),"\" c=\"",format(C),"\"", UVIndices,
-                VCol]),
+                VCol],[]),
 
 
     export_faces(F, T, DefaultMaterial, TxT, VColT).
@@ -4682,7 +4682,7 @@ export_light(F, Name, point, OpenGL, YafaRay) ->
     Position = proplists:get_value(position, OpenGL, {0.0,0.0,0.0}),
     Diffuse = proplists:get_value(diffuse, OpenGL, {1.0,1.0,1.0,1.0}),
     Type = proplists:get_value(type, YafaRay, ?DEF_POINT_TYPE),
-    println(F,"<light name=\"~s\"> <type sval=\"~w\"/>  <power fval=\"~.3f\"/> ",
+    uniprintln(F,"<light name=\"~ts\"> <type sval=\"~w\"/>  <power fval=\"~.3f\"/> ",
             [Name,Type,Power]),
     case Type of
         pointlight ->
@@ -4725,8 +4725,8 @@ export_light(F, Name, infinite, OpenGL, YafaRay) ->
     %% Directional Infinite Light Start
     case Type of
         directional when Power > 0.0 ->
-            println(F,"<light name=\"~s\"> <type sval=\"~w\"/> "++
-                        "<power fval=\"~.3f\"/>",
+            uniprintln(F,"<light name=\"~ts\"> <type sval=\"~w\"/> "++
+                         "<power fval=\"~.3f\"/>",
                     [Name, Type, Power]),
 
             %% Add Semi-infinite Start
@@ -4754,8 +4754,8 @@ export_light(F, Name, infinite, OpenGL, YafaRay) ->
         %% Directional Infinite Light End
         %% Sunlight Infinite Light Start
         sunlight when Power > 0.0 ->
-            println(F,"<light name=\"~s\"> <type sval=\"~w\"/> "++
-                        "<power fval=\"~.10f\"/> <samples ival=\"~w\"/> <angle fval=\"~.3f\"/>",
+            uniprintln(F,"<light name=\"~ts\"> <type sval=\"~w\"/> "++
+                         "<power fval=\"~.10f\"/> <samples ival=\"~w\"/> <angle fval=\"~.3f\"/>",
                     [Name, Type, Power, SunSamples, SunAngle]),
 
             export_pos(F, direction, Position),
@@ -4777,8 +4777,8 @@ export_light(F, Name, spot, OpenGL, YafaRay) ->
     ConeAngle = proplists:get_value(cone_angle, OpenGL, ?DEF_CONE_ANGLE),
     Diffuse = proplists:get_value(diffuse, OpenGL, {1.0,1.0,1.0,1.0}),
     Type = proplists:get_value(type, YafaRay, ?DEF_SPOT_TYPE),
-    println(F,"<light name=\"~s\"> <power fval=\"~.3f\"/> ",
-            [Name,Power]),
+    uniprintln(F,"<light name=\"~ts\"> <power fval=\"~.3f\"/> ",
+               [Name,Power]),
     case Type of
         spotlight ->
 
@@ -4813,8 +4813,8 @@ export_light(F, Name, spot, OpenGL, YafaRay) ->
             SpotIESSamples = proplists:get_value(spot_ies_samples, YafaRay,
                                                  ?DEF_SPOT_IES_SAMPLES),
 
-            println(F, "<type sval=\"ieslight\"/> <cone_angle fval=\"~.3f\"/> <soft_shadows bval=\"~s\"/> <samples ival=\"~w\"/>~n"++
-                        "       <file sval=\"~s\"/>",
+            uniprintln(F, "<type sval=\"ieslight\"/> <cone_angle fval=\"~.3f\"/> <soft_shadows bval=\"~s\"/> <samples ival=\"~w\"/>~n"++
+                          "       <file sval=\"~ts\"/>",
                     [ConeAngle,SpotSoftShadows,SpotIESSamples,SpotIESFilename])
     end,
     export_pos(F, from, Position),
@@ -4849,8 +4849,8 @@ export_light(F, Name, ambient, _OpenGL, YafaRay) ->
             Bg;
         hemilight -> Bg;
         pathlight when Power > 0.0 ->
-            println(F,"<light type sval=\"~w\" name sval=\"~s\" power fval=\"~.3f\"",
-                    [Type,Name,Power]),
+            uniprintln(F,"<light type sval=\"~w\" name sval=\"~ts\" power fval=\"~.3f\"",
+                       [Type,Name,Power]),
             UseQMC = proplists:get_value(use_QMC, YafaRay,
                                          ?DEF_USE_QMC),
             Depth = proplists:get_value(depth, YafaRay, ?DEF_DEPTH),
@@ -4919,7 +4919,7 @@ export_light(F, Name, ambient, _OpenGL, YafaRay) ->
             Bg;
         pathlight -> Bg;
         globalphotonlight ->
-            println(F,"<light type sval=\"~w\" name sval=\"~s\"", [Type,Name]),
+            uniprintln(F,"<light type sval=\"~w\" name sval=\"~ts\"", [Type,Name]),
             GplPhotons = proplists:get_value(
                            globalphotonlight_photons, YafaRay,
                            ?DEF_GLOBALPHOTONLIGHT_PHOTONS),
@@ -4962,9 +4962,9 @@ export_light(F, Name, area, OpenGL, YafaRay) ->
                   Pwr ->
                       NameI = Name++"_"++integer_to_list(I),
                       [A,B,C,D] = quadrangle_vertices(VsF, VsT),
-                      println(F, "<light name=\"~s\"> <type sval=\"arealight\"/>"
-                              "<power fval=\"~.3f\"/>~n"
-                              "<samples ival=\"~w\"/>"++
+                      uniprintln(F, "<light name=\"~ts\"> <type sval=\"arealight\"/>"
+                                    "<power fval=\"~.3f\"/>~n"
+                                    "<samples ival=\"~w\"/>"++
                                   if Dummy -> "";
                                      true ->
                                           ""
@@ -4984,7 +4984,7 @@ export_light(F, Name, area, OpenGL, YafaRay) ->
       end, 1, AFs),
     undefined;
 export_light(_F, Name, Type, _OpenGL, _YafaRay) ->
-    io:format(?__(1,"WARNING: Ignoring unknown light \"~s\" type: ~p")++"~n",
+    io:format(?__(1,"WARNING: Ignoring unknown light \"~ts\" type: ~p")++"~n",
               [Name, format(Type)]),
     undefined.
 
@@ -5027,7 +5027,7 @@ export_camera(F, Name, Attr) ->
     %% YafaRay focal plane is 1 unit wide.
     FocalDist = 0.5 / ((Width/Height) * math:tan(limit_fov(Fov)*0.5*Ro)),
     Aperture = proplists:get_value(aperture, Attr),
-    println(F, "<camera name=\"~s\"> "++
+    uniprintln(F, "<camera name=\"~ts\"> "++
                 "<resx ival=\"~w\"/> <resy ival=\"~w\"/> <focal fval=\"~.10f\"/>"++
                 if Aperture > 0.0 ->
                         "~n        <dof_distance fval=\"~.10f\"/> <aperture fval=\"~.10f\"/>"
@@ -5114,7 +5114,7 @@ export_background(F, Name, Ps) ->
 
             AmbientCausticPhotons = proplists:get_value(ambient_causticphotons, YafaRay, ?DEF_AMBIENT_CAUSTICPHOTONS),
 
-            print(F, "<background name=\"~s\">",
+            print(F, "<background name=\"~ts\">",
                 [Name]),
 
             println(F, "<type sval=\"~s\"/>",
@@ -5157,7 +5157,7 @@ export_background(F, Name, Ps) ->
             AmbientCausticPhotons = proplists:get_value(ambient_causticphotons, YafaRay, ?DEF_AMBIENT_CAUSTICPHOTONS),
 
 
-            print(F, "<background name=\"~s\">",
+            uniprint(F, "<background name=\"~ts\">",
                 [Name]),
 
             println(F, "<type sval=\"~s\"/>",
@@ -5208,7 +5208,7 @@ export_background(F, Name, Ps) ->
 
             Position = proplists:get_value(position, OpenGL, {1.0,1.0,1.0}),
 
-            print(F, "<background name=\"~s\"> <type sval=\"~s\"/>",
+            uniprint(F, "<background name=\"~ts\"> <type sval=\"~s\"/>",
                 [Name,format(Bg)]),
 
             println(F, "~n            <turbidity fval=\"~.3f\"/> <a_var fval=\"~.3f\"/>~n"
@@ -5274,7 +5274,7 @@ export_background(F, Name, Ps) ->
 
             Position = proplists:get_value(position, OpenGL, {1.0,1.0,1.0}),
 
-            print(F, "<background name=\"~s\"> <type sval=\"~s\"/>",
+            uniprint(F, "<background name=\"~ts\"> <type sval=\"~s\"/>",
                 [Name,format(Bg)]),
 
             println(F, "~n            <turbidity fval=\"~.3f\"/> <a_var fval=\"~.3f\"/>~n"
@@ -5389,13 +5389,13 @@ export_background(F, Name, Ps) ->
             AmbientCausticPhotons = proplists:get_value(ambient_causticphotons, YafaRay, ?DEF_AMBIENT_CAUSTICPHOTONS),
 
 
-            print(F, "<texture name=\"world_texture\">~n"
-            "        <filename sval=\"~s\"/>~n"
+            uniprint(F, "<texture name=\"world_texture\">~n"
+            "        <filename sval=\"~ts\"/>~n"
             "        <interpolate sval=\"bilinear\"/>~n"
             "        <type sval=\"image\"/>~n"
             "        </texture>",
                 [BgFname]),
-            println(F, "~n <background name=\"~s\"> <type sval=\"textureback\"/> ",
+            uniprintln(F, "~n <background name=\"~ts\"> <type sval=\"textureback\"/> ",
                 [Name]),
             println(F, "<power fval=\"~w\"/>~n"
             "<mapping sval=\"~s\"/>~n"
@@ -5441,13 +5441,13 @@ export_background(F, Name, Ps) ->
 
 
 
-            print(F, "<texture name=\"world_texture\">~n"
-            "        <filename sval=\"~s\"/>~n"
+            uniprint(F, "<texture name=\"world_texture\">~n"
+            "        <filename sval=\"~ts\"/>~n"
             "        <interpolate sval=\"bilinear\"/>~n"
             "        <type sval=\"image\"/>~n"
             "        </texture>",
                 [BgFname]),
-            println(F, "~n <background name=\"~s\"> <type sval=\"textureback\"/> ",
+            uniprintln(F, "~n <background name=\"~ts\"> <type sval=\"textureback\"/> ",
                 [Name]),
 
             println(F, " <power fval=\"~.3f\"/>~n"
@@ -5702,9 +5702,9 @@ export_render(F, CameraName, BackgroundName, Attr) ->
             println(F," ")
     end,
 
-    println(F, "<render>~n"
+    uniprintln(F, "<render>~n"
     "        <adv_computer_node ival=\"~w\"/>~n"
-    "        <camera_name sval=\"~s\"/>~n"
+    "        <camera_name sval=\"~ts\"/>~n"
     "        <filter_type sval=\"~s\"/>~n"
     "        <AA_passes ival=\"~w\"/>~n"
     "        <AA_threshold fval=\"~.10f\"/>~n"
@@ -5727,7 +5727,7 @@ export_render(F, CameraName, BackgroundName, Attr) ->
                 "        <premult bval=\"true\"/>~n";
             _ -> ""
         end++
-    "        <background_name sval=\"~s\"/>~n"++
+    "        <background_name sval=\"~ts\"/>~n"++
     "        <width ival=\"~w\"/> <height ival=\"~w\"/>~n"
     "        <gamma fval=\"~.10f\"/>~n"
     "        <adv_auto_shadow_bias_enabled bval=\"~s\"/>~n"
@@ -5800,15 +5800,15 @@ export_logging_badge(F, Attr) ->
     println(F, "	<logging_saveLog bval=\"~s\"/>", [LogSaveTxt]),
     println(F, "	<logging_saveHTML bval=\"~s\"/>", [LogSaveHtml]),
     println(F, "	<logging_paramsBadgePosition sval=\"~s\"/>", [BadgePosition]),
-    io:put_chars(F, unicode:characters_to_binary(io_lib:format("	<logging_title sval=\"~ts\"/>", [BadgeTitle]))),
-    io:put_chars(F, unicode:characters_to_binary(io_lib:format("	<logging_author sval=\"~ts\"/>~n", [BadgeAuthor]))),
-    io:put_chars(F, unicode:characters_to_binary(io_lib:format("	<logging_contact sval=\"~ts\"/>", [BadgeContact]))),
-    io:put_chars(F, unicode:characters_to_binary(io_lib:format("	<logging_comments sval=\"~ts\"/>", [BadgeComments]))),
-    println(F, "	<logging_customIcon sval=\"~s\"/>", [BadgeCustomIconPath]),
+    uniprintln(F, " <logging_title sval=\"~ts\"/>", [BadgeTitle]),
+    uniprintln(F, "	<logging_author sval=\"~ts\"/>", [BadgeAuthor]),
+    uniprintln(F, "	<logging_contact sval=\"~ts\"/>", [BadgeContact]),
+    uniprintln(F, "	<logging_comments sval=\"~ts\"/>", [BadgeComments]),
+    uniprintln(F, "	<logging_customIcon sval=\"~ts\"/>", [BadgeCustomIconPath]),
     println(F, "	<logging_drawRenderSettings bval=\"~s\"/>", [BadgeDrawRenderSettings]),
     println(F, "	<logging_drawAANoiseSettings bval=\"~s\"/>", [BadgeDrawAANoiseSettings]),
-    println(F, "	<logging_fontPath sval=\"~s\"/>~n", [Badge_font_path]),
-    println(F, "	<logging_fontSizeFactor fval=\"~.10f\"/>~n", [Badge_font_size_factor]),
+    uniprintln(F, "	<logging_fontPath sval=\"~ts\"/>", [Badge_font_path]),
+    println(F, "	<logging_fontSizeFactor fval=\"~.10f\"/>", [Badge_font_size_factor]),
     println(F, "</logging_badge>").
 
 
@@ -5852,6 +5852,24 @@ print(F, Format, Args) ->
 
 println(F, Format, Args) ->
     case file:write(F, [io_lib:format(Format, Args),io_lib:nl()]) of
+        ok ->
+            ok;
+        Error ->
+            erlang:error(Error, [F,Format,Args])
+    end.
+
+uniprint(F, Format, Args) ->
+    UnicodeText = io_lib:format(Format, Args),
+    case io:put_chars(F, unicode:characters_to_binary(UnicodeText)) of
+        ok ->
+            ok;
+        Error ->
+            erlang:error(Error, [F,Format,Args])
+    end.
+
+uniprintln(F, Format, Args) ->
+    UnicodeText = io_lib:format(Format, Args) ++ io_lib:nl(),
+    case io:put_chars(F, unicode:characters_to_binary(UnicodeText)) of
         ok ->
             ok;
         Error ->


### PR DESCRIPTION
- Fixed the missing format tag to output unicode chars on console (~ts);
- Addes the 'unicode' to option parameter in re functions call;
- Added a new print function (uniprint/ln) to handle lists which can have
  non-latim chars and was causing error on written to disk;

* Thanks to oort and tkbd for help me testing.